### PR TITLE
delete timestamp column if present

### DIFF
--- a/tabular/fraud/Models/fraud_model.py
+++ b/tabular/fraud/Models/fraud_model.py
@@ -7,4 +7,6 @@ cat_cols = ['category', 'card_type', 'card_company', 'city', 'browser_version', 
 def predict_df(df):
     for col in cat_cols:
         df[col] = df[col].astype(object)
+    if "timestamp" in df:
+      del df["timestamp"]
     return mod.predict_proba(df.fillna(0))[:,1]


### PR DESCRIPTION
in the eval dataset there is an extra timestamp column. this is causing any predictions on the eval dataset to fail

a possibly better solution is to remove the timestamp column from the eval dataset entirely. im assuming its there because we want it for firewall? why are we using the same dataset for stress test and firewall?