### PR TITLE
add stress config for fraud

### DIFF
--- a/tabular/fraud/stress_test_config.json
+++ b/tabular/fraud/stress_test_config.json
@@ -1,0 +1,13 @@
+{
+    "run_name": "Fraud",
+    "data_info": {
+        "pred_col": "preds",
+        "label_col": "label",
+        "ref_path": "fraud_ref.csv",
+        "eval_path": "fraud_eval.csv"
+    },
+    "model_info": {
+        "path": "Models/fraud_model.py"
+    },
+    "model_task":"Binary Classification"
+}


### PR DESCRIPTION
In reference to this PR https://github.com/RobustIntelligence/rime/pull/7009, we want to check in the stress test configs for each example. Then the script to seed the demo cluster can just pull each config from ri-public-examples and modify the paths accordingly to upload to S3. 


@RobustIntelligence/ml 
