### PR TITLE
add urls+configs for awa dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,18 @@ This is based on public NYC Taxi and Limousine Commission data (https://www1.nyc
 
 ### Classification
 
-#### 1. Arxiv (`nlp/classification/arxiv/`)
-TODO
+#### 1. ArXiv (`nlp/classification/arxiv/`)
+This is based on the [public ArXiv dataset](https://www.kaggle.com/datasets/Cornell-University/arxiv?select=arxiv-metadata-oai-snapshot.json).
+This directory contains an NLP topic classification model, reference set, evaluation set, and test sets representing production data.
 
 #### 2. Twitter Sentiment Analysis (`nlp/classification/sentiment_analysis/`)
-TODO
+This is based on the [CARER Emotion Recognition dataset](https://github.com/dair-ai/emotion_dataset).
+This directory contains a RoBERTA-based model trained on tweets and used for sentiment analysis. It also contains the reference set and test sets.
+
+## Computer Vision
+
+### Classification
+
+#### 1. Animals with Attributes 2 (`images/classification/awa2`)
+This is based on the [Animals with Attributes dataset](https://cvml.ist.ac.at/AwA2/).
+This directory contains an image classification model, a reference and evaluation set for stress testing, as well as a test set representing production data.

--- a/download_files.py
+++ b/download_files.py
@@ -10,14 +10,14 @@ def _fetch_urls_and_outpaths(file_path: Path) -> List[Tuple[str, str]]:
     urls_and_outpaths = []
     with open(file_path, "r") as fp:
         for line in fp:
-            tokens = tuple([t.strip() for t in line.split(',')])
+            tokens = [t.strip() for t in line.split(',')]
             if len(tokens) != 2:
                 raise Exception(
                     "Number of comma-separated values should be 2. "
                     f"Actual: {len(tokens)}"
                 )
 
-            urls_and_outpaths.append(tokens)
+            urls_and_outpaths.append((tokens[0], Path(tokens[1])))
     return urls_and_outpaths
 
 
@@ -32,6 +32,17 @@ def _download_files(urls_and_outpaths: List[Tuple[str, str]], parent_dir: Path) 
         if not outdir.exists():
             os.makedirs(outdir)
         subprocess.run(["wget", url, "-O", full_outpath])
+        # if downloading a zip file, unzip
+        if outpath.suffix == ".zip":
+            # unzip in parent directory
+            subprocess.run(["unzip", "-o", full_outpath, "-d", outdir])
+            # assert that the unzipped directory has same name as .zip file
+            full_outpath_unzip = outdir / (outpath.stem)
+            if not full_outpath_unzip.exists():
+                raise Exception(
+                    "The unzipped directory must exist at following output path: "
+                    f"{full_outpath_unzip}. Original zip path: {full_outpath}."
+                )
 
 
 def download_files(project_dir: Path) -> None:

--- a/download_files.py
+++ b/download_files.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 from pathlib import Path
 
 
-def _fetch_urls_and_outpaths(file_path: Path) -> List[Tuple[str, str]]:
+def _fetch_urls_and_outpaths(file_path: Path) -> List[Tuple[str, Path]]:
     """Fetch urls and output paths from text file."""
     urls_and_outpaths = []
     with open(file_path, "r") as fp:
@@ -21,7 +21,7 @@ def _fetch_urls_and_outpaths(file_path: Path) -> List[Tuple[str, str]]:
     return urls_and_outpaths
 
 
-def _download_files(urls_and_outpaths: List[Tuple[str, str]], parent_dir: Path) -> None:
+def _download_files(urls_and_outpaths: List[Tuple[str, Path]], parent_dir: Path) -> None:
     """Download files."""
     if not parent_dir.exists():
         os.makedirs(parent_dir)

--- a/download_files.py
+++ b/download_files.py
@@ -36,13 +36,6 @@ def _download_files(urls_and_outpaths: List[Tuple[str, Path]], parent_dir: Path)
         if outpath.suffix == ".zip":
             # unzip in parent directory
             subprocess.run(["unzip", "-o", full_outpath, "-d", outdir])
-            # assert that the unzipped directory has same name as .zip file
-            full_outpath_unzip = outdir / (outpath.stem)
-            if not full_outpath_unzip.exists():
-                raise Exception(
-                    "The unzipped directory must exist at following output path: "
-                    f"{full_outpath_unzip}. Original zip path: {full_outpath}."
-                )
 
 
 def download_files(project_dir: Path) -> None:

--- a/images/classification/awa2/configs/stress_test_config.json
+++ b/images/classification/awa2/configs/stress_test_config.json
@@ -1,0 +1,15 @@
+{
+    "run_name": "Image Classification",
+    "data_info": {
+        "ref_path": "data/train_inputs_trial.json",
+        "eval_path": "data/test_inputs_trial.json"
+    },
+    "data_profiling_info": {
+        "class_names": ["antelope", "grizzly+bear", "killer+whale", "beaver", "dalmatian", "horse", "german+shepherd", "blue+whale", "siamese+cat", "skunk", "mole", "tiger", "moose", "spider+monkey", "elephant", "gorilla", "ox", "fox", "sheep", "hamster", "squirrel", "rhinoceros", "rabbit", "bat", "giraffe", "wolf", "chihuahua", "weasel", "otter", "buffalo", "zebra", "deer", "bobcat", "lion", "mouse", "polar+bear", "collie", "walrus", "cow", "dolphin"]
+    },
+    "model_info": {
+        "path": "models/awa2_cpu.py"
+    },
+    "model_task": "Image Classification",
+    "tests_config_path": "fast_test_config.json"
+}

--- a/images/classification/awa2/data_urls.csv
+++ b/images/classification/awa2/data_urls.csv
@@ -1,0 +1,5 @@
+https://www.dropbox.com/s/658d2urffyxtsm4/test_inputs_monitoring_trial.json?dl=1,test_inputs_monitoring_trial.json
+https://www.dropbox.com/s/5hltd2z9r48vflv/train_inputs_trial.json?dl=1,train_inputs_trial.json
+https://www.dropbox.com/s/6oql2ks9b1icntd/test_inputs_trial.json?dl=1,test_inputs_trial.json
+https://www.dropbox.com/s/7d0262dmzwao2lt/s3_image_loader.py?dl=1,s3_image_loader.py
+https://www.dropbox.com/s/lynk24kjharvqle/JPEGImages.zip?dl=1,JPEGImages.zip

--- a/images/classification/awa2/fast_test_config.json
+++ b/images/classification/awa2/fast_test_config.json
@@ -1,0 +1,20 @@
+{
+    "horizontal_flip": {
+        "sample_size": 20
+    },
+    "vertical_flip": {
+        "sample_size": 20
+    },
+    "gaussian_blur": {
+        "sample_size": 20
+    },
+    "color_jitter": {
+        "sample_size": 20
+    },
+    "randomize_pixels_with_mask": {
+        "sample_size": 20
+    },
+    "gaussian_noise": {
+        "sample_size": 20
+    }
+}

--- a/images/classification/awa2/model_urls.csv
+++ b/images/classification/awa2/model_urls.csv
@@ -1,0 +1,2 @@
+https://www.dropbox.com/s/2u4sld8g2dslony/awa2_cpu.py?dl=1,awa2_cpu.py
+https://www.dropbox.com/s/ghe4wvhz65glbh5/model.pt?dl=1,model.pt


### PR DESCRIPTION
Adding URLs + configs for the awa2 dataset to ri-public-examples.

I thought about how to have the download_files script also download all the raw image files. Copying and pasting the link of every image file into data_urls.csv is obviously a terrible idea. In the end I decided to add some custom logic to `download_files.py` such that if the downloaded URL is a zip file, we'll also unzip it. This allows me to upload the raw image directory as a zip file, and the script will unzip the image files after it's downloaded. Feel free to try it out! 

Tagging @asamant22 on this since it seems like you're adding more data files to Dropbox - I can update this PR accordingly.

Closes RIME-8929
@RobustIntelligence/ml 