### PR TITLE
create dirs if don't exist

### DIFF
--- a/ri_public_examples/download_files.py
+++ b/ri_public_examples/download_files.py
@@ -12,6 +12,8 @@ DEFAULT_CONFIG_PATH = "configs/stress_test_config.json"
 
 def _download_file(remote_path: str, local_path: Path) -> None:
     """Downloads file to local path."""
+    if not local_path.parent.exists():
+        local_path.parent.mkdir(parents=True)
     r = requests.get(remote_path)
     with open(local_path, 'wb') as f:
         f.write(r.content)


### PR DESCRIPTION
Posting for visibility, going to force-merge. Fixing a bug where if directories don't exist (specified in the data or model paths e.g. model_extras) then the file download fails 