### PR TITLE
add custom metrics file for fraud

### DIFF
--- a/tabular/fraud/model_urls.csv
+++ b/tabular/fraud/model_urls.csv
@@ -4,3 +4,4 @@ https://www.dropbox.com/s/p221li9slma84pb/fraud_model2.catb?dl=1,fraud_model2.ca
 https://www.dropbox.com/s/sge8yb0kwmkj41x/fraud_model2.py?dl=1,fraud_model2.py
 https://www.dropbox.com/s/9vyy01kbeuaekgs/fraud_model3.catb?dl=1,fraud_model3.catb
 https://www.dropbox.com/s/q6kcfiyjf4tia22/fraud_model3.py?dl=1,fraud_model3.py
+https://www.dropbox.com/s/c07meg2qp54v0u4/custom_metric.py?dl=1,custom_metrics.py


### PR DESCRIPTION
Planning to define custom metrics in the fraud notebook (which is the primary entrypoint for users using the demo notebooks). It's the existing demo custom metric of average nulls per row. 