### PR TITLE
Update links for AWA2 data files

### DIFF
--- a/images/classification/awa2/data_urls.csv
+++ b/images/classification/awa2/data_urls.csv
@@ -1,5 +1,5 @@
-https://www.dropbox.com/s/3yjxpqgytg44597/test_inputs_monitoring_trial.json?dl=1,test_inputs_monitoring_trial.json
-https://www.dropbox.com/s/issf8sr9l6deeev/train_inputs_trial.json?dl=1,train_inputs_trial.json
-https://www.dropbox.com/s/z5yf4c089ds8dj3/test_inputs_trial.json?dl=1,test_inputs_trial.json
+https://www.dropbox.com/scl/fi/88ekky3j685g6baufqs7l/test_inputs_monitoring_trial.json?rlkey=1xrbf06jrdr343z8x89dha9rm&dl=1,test_inputs_monitoring_trial.json
+https://www.dropbox.com/scl/fi/k2rwq4hgq5iwt36ri0yp5/train_inputs_trial.json?rlkey=v0bymda3ahrl533a0skrqfjgj&dl=1,train_inputs_trial.json
+https://www.dropbox.com/scl/fi/sfi164oebibzi6bq3t8hm/test_inputs_trial.json?rlkey=cr76wh75zyxn9w82jslvk26c1&dl=1,test_inputs_trial.json
 https://www.dropbox.com/s/1ec3r776v6ylyoh/s3_image_loader.py?dl=1,s3_image_loader.py
-https://www.dropbox.com/s/w3im90encnf2l6y/JPEGImages.zip?dl=1,JPEGImages.zip
+https://www.dropbox.com/scl/fi/6zfxy8ux80w4jf4scfg0j/JPEGImages.zip?rlkey=f5xylpx19wipa8u4lvgdl78fu&dl=1,JPEGImages.zip


### PR DESCRIPTION
Specific changes the underlying data at those urls:
- Resized all the images to be 224 x 224. Previously many images had h/w over 1000, and the large data sizes would result in the pod OOMing if you ran the Adversarial category (square attack in particular I think—I'll eventually look into the issue at its root at some point), which is why we never have any CV adversarial test runs up on gallery. Note that when we display images in the UI, they already get reshaped to 224 x 224, so there was really never any reason for the raw data to be that big.
- Removed predictions from the input data. It technically wasn't a problem, but it's just an extraneous remnant from our pre-2.0 format, so I wanted to remove it lest users look at it and get confused.

Confirmed that I was able to successfully run a [stress test](https://rime.latest.rbst.io/stress-testing/00858371-2829-4bee-9b20-0fe5d500f947/test-runs/55cb8dcd-1af3-49ce-aff3-3e27771dcfcb/by-test) with adversarial category turned on.