### PR TITLE
Remove lending model_task.pkl file from tabular-2.0

### DIFF
--- a/tabular-2.0/lending/model_urls.csv
+++ b/tabular-2.0/lending/model_urls.csv
@@ -1,7 +1,6 @@
 https://www.dropbox.com/s/5ib4po1jeyrjtd5/cat_features.pkl?dl=1,model_extras/cat_features.pkl
 https://www.dropbox.com/s/a31bawgvpa4yhdp/class_name.pkl?dl=1,model_extras/class_names.pkl
 https://www.dropbox.com/s/0k3cxnp6fsslfi5/cont_features.pkl?dl=1,model_extras/cont_features.pkl
-https://www.dropbox.com/s/y1oyitu7g0x5dvu/model_task.pkl?dl=1,model_extras/model_task.pkl
 https://www.dropbox.com/s/7mjffja2skqawbq/model.catb?dl=1,model_extras/model.catb
 https://www.dropbox.com/s/qr8832hmezt7jxj/preprocessor.pkl?dl=1,model_extras/preprocessor.pkl
 https://www.dropbox.com/s/95t6f89u337qpg7/model.py?dl=1,model.py


### PR DESCRIPTION
We removed the model_task.pkl file from dropbox and from the tabular/lending/model_urls.csv but not from the tabular-2.0 folder. This was raising a warning in the notebook. 